### PR TITLE
downgrade setup-ruby to v1

### DIFF
--- a/.github/workflows/update-faa-dtpp-metafile.yml
+++ b/.github/workflows/update-faa-dtpp-metafile.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v2
+      uses: ruby/setup-ruby@v1
     - name: Install dependencies
       run: gem install airac ox
     - name: Retrieve d-TPP Metafile from FAA and save output as JSON


### PR DESCRIPTION
v2 doesn't exist